### PR TITLE
feat: add user and admin auth and validate schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+
+require('dotenv').config();
 const express = require("express");
 const { userRouter } = require("./src/routes/userRoutes");
 const { adminRouter } = require("./src/routes/adminRoutes");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,27 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.15.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -25,6 +40,24 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -271,6 +304,17 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -634,6 +678,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "description": "",
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.0"
   },

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -1,0 +1,93 @@
+const { adminModel } = require("../model/admin.schema");
+const { courseModel } = require("../model/course.schema");
+const { hashedPassword, comparePassword } = require("../utils/bcrypt");
+const { generateToken } = require("../utils/jwt");
+
+const signup = async (req, res) => {
+  const { email, password, firstName, lastName } = req.body;
+
+  const hashPassword = await hashedPassword(password);
+
+  const admin = await adminModel.create({
+    email,
+    password: hashPassword,
+    firstName,
+    lastName,
+  });
+
+  res.status(201).json({
+    msg: "User signed up successfully",
+  });
+};
+
+const signin = async (req, res) => {
+  const { email, password } = req.body;
+
+  const admin = await adminModel.findOne({ email });
+
+  if (!admin) return res.status(404).json({ error: "admin not found" });
+
+  const isMatched = await comparePassword(password, admin.password);
+
+  if (!isMatched) return res.status(401).json({ error: "invalid password" });
+
+  const token = generateToken({ adminId: admin._id, email: admin.email });
+
+  res.status(200).json({
+    msg: "admin successfullu signed in",
+    token,
+    admin: {
+      email: admin.email,
+    },
+  });
+};
+
+const createCourse = async (req, res) => {
+  const { title, description, price, imageUrl } = req.body;
+
+  const adminId = req.user.adminId;
+
+  const course = await courseModel.create({
+    title,
+    description,
+    price,
+    imageUrl,
+    creatorId: adminId,
+    isPublished: false,
+  });
+  await adminModel.findByIdAndUpdate(adminId, {
+    $push: { createdCourses: course._id },
+  });
+  res.status(201).json({
+    msg: "Course created successfully",
+    course,
+  });
+};
+
+const updateCourse = async (req, res) => {
+  const { courseId } = req.params;
+  const adminId = req.user.adminId;
+
+  const course = await courseModel.findByIdAndUpdate(
+    { _id: courseId, creatorId: adminId },
+    req.body,
+    { new: true }
+  );
+
+  if (!course) return res.status(404).json({ error: "course not found" });
+
+  res.status(200).json({
+    msg: "course updated successfully",
+  });
+};
+
+const getCourse=async(req , res)=>{
+    const adminId=req.user.adminId;
+    const course=await courseModel.find({creatorId:adminId})
+    res.status(200).json({course:course})
+}
+
+module.exports={
+    signup,signin,createCourse,getCourse,updateCourse
+}
+

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,69 @@
+const { courseModel } = require("../model/course.schema");
+const { purchaseModel } = require("../model/purchase.Schema");
+const { userModel } = require("../model/user.schema");
+const { hashedPassword, comparePassword } = require("../utils/bcrypt");
+const { generateToken } = require("../utils/jwt");
+
+
+const signup=async(req , res)=>{
+    const {email,password,firstName,lastName}=req.body;
+    const hashPassword=await hashedPassword(password)
+
+    const user=await userModel.create({
+        email,password:hashPassword,firstName,lastName
+    })
+
+    res.status(201).json({
+        msg:"user signed up successfully"
+    })
+}
+
+const signin=async(req ,res)=>{
+    const {email,password}=req.body
+    
+    const user=await userModel.findOne({email})
+
+    if(!user) return res.status(404).json({error:"user not found"})
+
+    const isMatched=await comparePassword(password,user.password)
+    
+    if (!isMatched) return res.status(401).json({error:"Invalid password"})
+
+    const token=generateToken({userId:user._id,email:user.email})
+    
+    res.status(200).json({
+        msg:"user signed in successfully",
+        token,
+        user:{email:user.email,firstName:user.firstName,lastName:user.lastName}
+    })
+}
+
+const purchaseCourse=async(req,res)=>{
+    const {courseId}=req.body
+    const userId=req.user.userId
+    const course=await courseModel.findById(courseId)
+
+    if(!course || !course.isPublished){
+        return res.status(404).json({error:"Course not found or not published"})
+    }
+
+    const purchase=await purchaseModel.create({
+        userId,
+        courseId,
+        amount:course.price,
+        status:"completed"
+
+    })
+
+    await userModel.findByIdAndUpdate(userId,{$push:{purchases:purchase._id}})
+    res.status(201).json({msg:"course purchase successfully"})
+}
+
+const getPurchases=async(req,res)=>{
+    const purchases=await purchaseModel.find({userId:req.user.userId}).populate("courseId")
+    res.status(200).json({purchases})
+}
+
+module.exports={
+    signin,signup,purchaseCourse,getPurchases
+}

--- a/src/middleware/authenticate.js
+++ b/src/middleware/authenticate.js
@@ -1,0 +1,22 @@
+
+const {verifyToken}=require("../utils/jwt")
+
+const authenticateToken=(req,res,next)=>{
+    const authHaeder=req.headers["authorization"]
+    const token=authHaeder && authHaeder.split(" ")[1]
+
+
+    if(!token) return res.status(401).json({error:"Access token required"})
+
+        try {
+            const decode=verifyToken(token)
+            req.user=decode
+            next()
+        } catch (error) {
+            return res.status(403).json({error:"Invalid or expired token"})
+        }
+}
+
+module.exports={
+    authenticateToken
+}

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,8 @@
+const errorHandler=(err,req,res)=>{
+    console.log(err.message)
+    res.status(500).json({error:"something went wrong"})
+}
+
+module.exports={
+    errorHandler
+}

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -1,95 +1,15 @@
 const { Router } = require("express");
-const bcrypt = require("bcrypt");
-const jwt = require("jsonwebtoken");
-const { adminModel } = require("../model/user.schema");
-const JWT_ADMIN_SCERET = "JWT_ADMIN_SCERET";
+const { adminSchema, courseSchema, validate } = require("../utils/validator");
+const { signup, signin, createCourse, updateCourse, getCourse } = require("../controllers/adminController");
+const { authenticateToken } = require("../middleware/authenticate");
 
 const adminRouter = Router();
 
-adminRouter.post("/signup", async (req, res) => {
-  const { email, password, firstName, lastName } = req.body;
-  try {
-    if (!email || !password || !firstName || !lastName) {
-      return res.status(400).json({
-        error: "All fields are required",
-      });
-    }
-    // hashed password
-
-    const adminhashedPassword = await bcrypt.hash(password, 5);
-
-    await adminModel.create({
-      email: email,
-      password: adminhashedPassword,
-      firstName: firstName,
-      lastName: lastName,
-    });
-
-    return res.status(201).json({
-      msg: "admin successfullly sign up",
-    });
-  } catch (error) {
-    console.log("error while doing admin sign up", error.message);
-    return res.status(500).json({
-      error: "failed to sign up",
-    });
-  }
-});
-adminRouter.post("/signin", async (req, res) => {
-  const { email, password } = req.body;
-  try {
-    if (!email || !password) {
-      return res.status(400).json({ error: "email and password is required" });
-    }
-    const admin = await adminModel.findOne({ email });
-
-    if (!admin) {
-      return res.status(400).json({ error: "admin not found" });
-    }
-
-    const adminPassIsMatched = await  bcrypt.compare(password, admin.password);
-    if (!adminPassIsMatched) {
-      return res.status(400).json({
-        error: "invalid password",
-      });
-    }
-
-    const token = jwt.sign(
-      {
-        id: admin._id,
-      },
-      JWT_ADMIN_SCERET
-    );
-
-    return res.status(201).json({
-      msg: "admin signin successfully",
-      token,
-      admin: {
-        email: admin.email,
-      },
-    });
-  } catch (error) {
-    console.log("error while signing ", error.message);
-    return res.status(500).json({
-      error: "failed to sign in",
-    });
-  }
-});
-adminRouter.post("/course", (req, res) => {
-  res.json({
-    user: "courses endpoints",
-  });
-});
-adminRouter.put("/course", (req, res) => {
-  res.json({
-    user: "courses endpoints",
-  });
-});
-adminRouter.get("/course/bulk", (req, res) => {
-  res.json({
-    user: "bulk endpoints",
-  });
-});
+adminRouter.post('/signup',validate(adminSchema),signup)
+adminRouter.post('/signin',validate(adminSchema),signin)
+adminRouter.post('/course',authenticateToken ,validate(courseSchema),createCourse)
+adminRouter.put('/course/:courseId',authenticateToken,updateCourse)
+adminRouter.get('/course/buld',authenticateToken,getCourse)
 
 module.exports = {
   adminRouter: adminRouter,

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,79 +1,13 @@
 const { Router } = require("express");
-const bcrypt = require("bcrypt");
-const jwt = require("jsonwebtoken");
-const { userModel } = require("../model/user.schema");
-const JWT_SCRERT = "JWT_SCERET";
+const { userSchema, validate } = require("../utils/validator");
+const { signup, signin, purchaseCourse, getPurchases } = require("../controllers/userController");
 
 const userRouter = Router();
 
-userRouter.post("/signup", async (req, res) => {
-  const { email, password, firstName, lastName } = req.body;
-  try {
-    if (!email || !password || !firstName || !lastName) {
-      return res.status(400).json({ error: "All fields required" });
-    }
-    // hash passwod
-    const hashedPassword = await bcrypt.hash(password, 5);
-
-    await userModel.create({
-      email: email,
-      password: hashedPassword, // hashed password
-      firstName: firstName,
-      lastName: lastName,
-    });
-
-    return res.status(201).json({
-      msg: "user successfully signup",
-    });
-  } catch (error) {
-    console.error("Error while doing signup:", error.message);
-    return res.status(500).json({ error: "Failed to sign up user" });
-  }
-});
-userRouter.post("/signin", async (req, res) => {
-  const { email, password } = req.body;
-
-  try {
-    // validate input
-    if (!email || !password) {
-      return res.status(400).json({ error: "email and password are required" });
-    }
-    // find user by email
-    const user = await userModel.findOne({ email });
-    console.log("user: ", user);
-    if (!user) {
-      return res.json({ error: "user not found" });
-    }
-    // compare the provided password and stored password
-    const isMatched = bcrypt.compare(password, user.password);
-    if (!isMatched) {
-      return res.status(400).json({ error: "invalid password" });
-    }
-    // generate jwt token
-
-    const token = jwt.sign(
-      {
-        id: user._id,
-      },
-      JWT_SCRERT
-    );
-    return res.status(200).json({
-      msg: "user successfully sign in ",
-      token,
-      user: {
-        email: user.email,
-      },
-    });
-  } catch (error) {
-    console.error("Error while signing in:", error.message);
-    return res.status(500).json({ error: "Failed to sign in" });
-  }
-});
-userRouter.get("/purchase", (req, res) => {
-  res.json({
-    user: "user purchased",
-  });
-});
+userRouter.post('/signup',validate(userSchema),signup)
+userRouter.post('/signin',validate(userSchema),signin)
+userRouter.post('/purchase',validate(userSchema),purchaseCourse)
+userRouter.get('/purchases',validate(userSchema),getPurchases)
 
 module.exports = {
   userRouter: userRouter,

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,13 @@
+const jwt=require("jsonwebtoken")
+
+const generateToken=(payload)=>{
+    return jwt.sign(payload,process.env.JWT_SECRET,{expiresIn:"1hr"})
+}
+
+const verifyToken=(token)=>{
+    return jwt.verify(token,process.env.JWT_SECRET)
+}
+
+module.exports={
+    generateToken,verifyToken
+}

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,0 +1,37 @@
+const Joi = require("joi");
+
+const userSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().min(8).required(),
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+});
+
+const adminSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().min(8).required(),
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+});
+
+const courseSchema = Joi.object({
+  title: Joi.string().required(),
+  description: Joi.string().required(),
+  price: Joi.number().min(0).required(),
+  imgaeUrl: Joi.string().uri().optional(),
+});
+
+const purchaseSchema = Joi.object({
+  courseId: Joi.string().required(),
+});
+
+const validate = (schema) => (req, res, next) => {
+  const { error } = schema.validate(req.body);
+
+  if (error) return res.status(400).json({ error: error.details[0].message });
+  next();
+};
+
+module.exports={
+    validate,userSchema,adminSchema,purchaseSchema,courseSchema
+}


### PR DESCRIPTION
## **Auth System Implementation**
- Added JWT authentication for users/admins
- Created schema validators for:
  - User signup/login
  - Admin signup/login
- Implemented middleware to:
  - Verify tokens
  - Check admin privileges

## **How to Test**
1. Register a user at `POST /api/v1/user/signup`
2. Login at `POST / /api/v1/user/signin`      // same as admin need to change only from user to admin
3. Use returned token in `Authorization: Bearer <token>` header
